### PR TITLE
remove through as a direct dependency

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,7 +3,7 @@
 // these things are okay, because CLI
 /* eslint-disable no-process-exit, no-console */
 
-var through = require('through2');
+var through = require('node-stream').through;
 
 var argv = require('../lib/argv.js');
 
@@ -43,4 +43,3 @@ toolkit({
   command: command,
   argv: argv
 });
-

--- a/lib/command-stream.js
+++ b/lib/command-stream.js
@@ -1,5 +1,5 @@
 var _ = require('lodash');
-var through = require('through2');
+var through = require('node-stream').through;
 
 module.exports = function commandStream(dataFn, flush) {
   // eslint-disable-next-line no-underscore-dangle

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,7 +1,7 @@
 /* jshint node: true */
 
 var _ = require('lodash');
-var through = require('through2');
+var through = require('node-stream').through;
 
 var pretrim = require('./util/pretrim.js');
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "lodash": "^4.13.1",
     "node-stream": "^1.1.0",
-    "through2": "^2.0.1",
     "yargs": "^6.4.0"
   },
   "devDependencies": {

--- a/test/command-stream.test.js
+++ b/test/command-stream.test.js
@@ -1,7 +1,7 @@
 /* jshint node: true, mocha: true */
 
 var expect = require('chai').expect;
-var through = require('through2');
+var through = require('node-stream').through;
 var _ = require('lodash');
 
 var commandStream = require('../lib/command-stream.js');

--- a/test/command/sort.test.js
+++ b/test/command/sort.test.js
@@ -1,7 +1,7 @@
 var expect = require('chai').expect;
 var _ = require('lodash');
 var ns = require('node-stream');
-var through = require('through2');
+var through = ns.through;
 
 var sort = require('../../lib/command/sort.js');
 

--- a/test/toolkit.test.js
+++ b/test/toolkit.test.js
@@ -5,10 +5,10 @@ var util = require('util');
 
 var expect = require('chai').expect;
 var _ = require('lodash');
-var through = require('through2');
-var ns = require('node-stream');
 var shellton = require('shellton');
 var root = require('rootrequire');
+var ns = require('node-stream');
+var through = ns.through;
 
 var toolkit = require('../toolkit.js');
 

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,8 +1,8 @@
 /* jshint node: true, mocha: true */
 
 var expect = require('chai').expect;
-var through = require('through2');
 var ns = require('node-stream');
+var through = ns.through;
 
 var util = require('../lib/util.js');
 

--- a/toolkit.js
+++ b/toolkit.js
@@ -2,7 +2,7 @@
 
 var _ = require('lodash');
 var ns = require('node-stream');
-var through = require('through2');
+var through = ns.through;
 
 var commands = require('./lib/command.js');
 var util = require('./lib/util.js');


### PR DESCRIPTION
It's built into `node-stream`, so I just don't want to install it twice.